### PR TITLE
Embed video on home page

### DIFF
--- a/src/components/pages/Home.js
+++ b/src/components/pages/Home.js
@@ -8,6 +8,17 @@ function Home () {
   return (
     <>
       <HeroSection />
+      <div className='home-video'>
+        <iframe
+          width="560"
+          height="315"
+          src="https://www.youtube.com/embed/1nt_b1U2CoY"
+          title="YouTube video player"
+          frameBorder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+        />
+      </div>
       <Cards />
     </>
   )


### PR DESCRIPTION
## Summary
- embed YouTube clip above card section on the Home page
- trim duplicate export line at end of Home.js

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b6bae8fc08322b2c6bab7d472e9ad